### PR TITLE
[FIX] Deleted force_symlink import

### DIFF
--- a/core/trainer.py
+++ b/core/trainer.py
@@ -18,7 +18,6 @@ from core.utils import (
     TensorboardWriter,
     count_parameters,
     create_dirs,
-    force_symlink,
     get_local_time,
     init_logger,
     init_seed,


### PR DESCRIPTION
force_symlink was removed in #17, but persisted in core/trainer.py:
https://github.com/RL-VIG/LibFewShot/blob/b050c06eb982defe57be7381e2877571ff561987/core/trainer.py#L20-L22
This was causing an import error.